### PR TITLE
Filtering options for guppy diplac

### DIFF
--- a/pplacer_src/guppy_diplac.ml
+++ b/pplacer_src/guppy_diplac.ml
@@ -19,9 +19,9 @@ object (self)
   inherit placefile_cmd () as super_placefile
   inherit output_cmd () as super_output
 
-  val max_dist = flag "--md"
+  val max_dist = flag "--min-distance"
     (Needs_argument ("min distance", "Specify the minimum distance to leaves to report"))
-  val max_reported = flag "--mr"
+  val max_reported = flag "--max-matches"
     (Needs_argument ("N", "Only report the deepest N placements"))
 
   method specl = super_mass#specl @ [


### PR DESCRIPTION
Added
- --min-distance flag to specify the minimum distance to leaves to report
- --max-matches flag to only report the deepest N placements
