### PR TITLE
hybrid5-- no big jumps in taxonomic hierarchy

### DIFF
--- a/pplacer_src/guppy_classify.ml
+++ b/pplacer_src/guppy_classify.ml
@@ -320,7 +320,7 @@ object (self)
   method private merge_hybrid5 td pp nbc =
     let nbc_rank, nbc_best = IntMap.max_binding nbc.tiamrim in
     match IntMap.split nbc_rank pp.tiamrim with
-    | pp_above, Some pp_best, _ ->
+    | _, Some pp_best, pp_above ->
       if IntMap.cardinal pp_above <= 1
         && on_lineage
           td


### PR DESCRIPTION
Hybrid5 should be like hybrid2, except that if the pplacer classification is two ranks more specific than the NBC classification, then we take the NBC classification (I would like to see some examples where this behavior is observed).
