### PR TITLE
Uninformative error when reference and query sequence IDs overlap

### DIFF
--- a/pplacer_src/pplacer_run.ml
+++ b/pplacer_src/pplacer_run.ml
@@ -659,11 +659,11 @@ let partition_queries ref_name_set aln =
          Using supplied reference alignment.\n";
     None
   end
+  else if Array.length ref_aln <> StringSet.cardinal ref_name_set then
+    failwith
+      "Some, but not all reference sequences found in provided alignment file. \
+         Are there overlaps between query and reference sequence IDs?";
   else begin
-    if Array.length ref_aln <> StringSet.cardinal ref_name_set then
-      failwith "Some, but not all reference sequences \
-                 found in alignment file. Are there overlaps between sequence IDs?";
-
     dprint
       "Found reference sequences in given alignment file. \
          Using those for reference alignment.\n";
@@ -772,4 +772,3 @@ let run_file prefs query_fname =
     run_placements
       prefs rp query_list from_input_alignment query_bname placerun_cb
   end
-


### PR DESCRIPTION
It looks like pplacer only checks to see if _any_ of the reference sequence IDs are present in the input alignment, rather than that they are all present.

This causes a problem when query sequences share names with reference sequences - in my case, I got the error:

```
Uncaught exception: Failure("Sequence 77900 doesn't overlap any reference sequences.")
Fatal error: exception Failure("Sequence 77900 doesn't overlap any reference sequences.")
Raised at file "pervasives.ml", line 22, characters 22-33
Re-raised at file "printexc.ml", line 71, characters 10-11
Called from file "list.ml", line 0, characters 0-0
```

See:
https://github.com/matsen/pplacer/blob/master/pplacer_src/pplacer_run.ml#L628-646
