### PR TITLE
Fix hanging issue on macOS ARM64 by forcing single process mode

### DIFF
--- a/pplacer_src/prefs.ml
+++ b/pplacer_src/prefs.ml
@@ -295,6 +295,19 @@ let check p =
     failwith "Starting pendant branch length must be strictly positive.";
   if start_pend p >= max_pend p then
     failwith "Starting pendant branch length must be strictly less than maximum pendant branch length.";
+  (* Work around hanging issue on macOS ARM64 by forcing single process mode *)
+  if children p > 0 && Sys.os_type = "Unix" then begin
+    try
+      let ic = Unix.open_process_in "uname -s -m" in
+      let line = input_line ic in
+      let _ = Unix.close_process_in ic in
+      if String.trim line = "Darwin arm64" then begin
+        Printf.printf "macOS ARM64 detected; using single process mode to avoid hanging issue.\n";
+        p.children := 0
+      end
+    with _ -> (* ignore errors in platform detection *)
+      ()
+  end;
   ()
 
 let usage =


### PR DESCRIPTION
Resolves #387 where pplacer hangs after "Preparing the edges for baseball... done." on macOS ARM64. The issue occurs in the multiprocessing event loop where Unix.select communication between parent and child processes fails on this platform.

The fix automatically detects macOS ARM64 and forces single process mode (children = 0) with a clear user message. This provides the same functionality while avoiding the hanging behavior.

- Detects macOS ARM64 using uname -s -m
- Automatically sets children = 0 when detected
- Provides informative message to user
- Only affects macOS ARM64, other platforms unchanged
- Works with both default (-j 2) and explicit (-j 0) flags

🤖 Generated with [Claude Code](https://claude.ai/code)