### PR TITLE
Fix assertion failure in three_tax.ml from Brent optimization bounds

### DIFF
--- a/pplacer_src/three_tax.ml
+++ b/pplacer_src/three_tax.ml
@@ -39,9 +39,12 @@ struct
     Glv_edge.set_bl tt.model tt.pend pend_bl
 
   let set_dist_bl tt dist_bl =
-    let prox_bl = (get_cut_bl tt) -. dist_bl in
-    assert(prox_bl >= 0.);
-    Glv_edge.set_bl tt.model tt.dist dist_bl;
+    (* Clamp dist_bl to [0, cut_bl] to handle floating-point precision issues
+       from Brent minimization that can return values slightly outside bounds *)
+    let cut_bl = get_cut_bl tt in
+    let clamped_dist_bl = max 0. (min dist_bl cut_bl) in
+    let prox_bl = cut_bl -. clamped_dist_bl in
+    Glv_edge.set_bl tt.model tt.dist clamped_dist_bl;
     Glv_edge.set_bl tt.model tt.prox prox_bl
 
   (* we minimize the negative of the log likelihood *)


### PR DESCRIPTION
## Summary
- Fixes `three_tax.ml:43` assertion failure reported by @Yiran-Yin in #391 comments
- GSL's Brent minimization can return values slightly outside the specified bounds due to floating-point precision
- This caused `dist_bl > cut_bl`, making `prox_bl` go negative and triggering the assertion
- Fix: clamp `dist_bl` to `[0, cut_bl]` before computing `prox_bl`

## Test plan
- [x] Reproduced the issue with the user's minimal test data (4886 reads)
- [x] Verified fix allows all reads to process successfully
- [x] Output jplace file generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)